### PR TITLE
Fixes #86

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: RSiteCatalyst
 Type: Package
 Title: R Client for Adobe Analytics API v1.4
-Version: 1.4.0
-Date: 2014-09-01
+Version: 1.4.0.20140919
+Date: 2014-09-19
 Author: Willem Paling, Randy Zwitch & Jowanza Joseph
 Maintainer: Randy Zwitch <rzwitch+rsitecatalyst@gmail.com>
 Depends:

--- a/R/QueueRanked.R
+++ b/R/QueueRanked.R
@@ -102,7 +102,7 @@ QueueRanked <- function(reportsuite.id, date.from, date.to, metrics, elements,
                                             keywords = search)
       }
     } else {
-      working.element <- list(id = unbox(element))
+      working.element <- list(id = unbox(element), top = unbox("50000"))
     }
 
     if(length(elements.formatted)>0) {

--- a/R/RSiteCatalyst.R
+++ b/R/RSiteCatalyst.R
@@ -1,7 +1,7 @@
 #' Package:  RSiteCatalyst \cr
 #' Type:     Package \cr
-#' Version:  1.4.0 \cr
-#' Date:     2014-08-26 \cr
+#' Version:  1.4.0.20140919 \cr
+#' Date:     2014-09-19 \cr
 #' License:  MIT + file LICENSE \cr
 #'
 #'

--- a/man/RSiteCatalyst.Rd
+++ b/man/RSiteCatalyst.Rd
@@ -13,8 +13,8 @@ This package is not intended for Adobe Analytics administration.
 \details{
 Package:  RSiteCatalyst \cr
 Type:     Package \cr
-Version:  1.4.0 \cr
-Date:     2014-08-26 \cr
+Version:  1.4.0.20140919 \cr
+Date:     2014-09-19 \cr
 License:  MIT + file LICENSE \cr
 }
 \author{


### PR DESCRIPTION
Adds back up to 50000 results returned for secondary element breakdown through hardcoding. Assumption is using top you would limit the handful of pages you want to see, but want to see all breakdowns.

Used to be hardcoded at a million, now API comically checks value
