### PR TITLE
Implement Aggregate date granularity in Overtime and Trended Reports.

### DIFF
--- a/R/QueueOvertime.R
+++ b/R/QueueOvertime.R
@@ -15,7 +15,7 @@
 #' @param date.from Start date for the report (YYYY-MM-DD)
 #' @param date.to End date for the report (YYYY-MM-DD)
 #' @param metrics List of metrics to include in the report
-#' @param date.granularity Time granularity of the report (year/month/week/day/hour), default to 'day'
+#' @param date.granularity Time granularity of the report (year/month/week/day/hour/aggregate), default to 'day'
 #' @param segment.id Id of Adobe Analytics segment to retrieve the report for
 #' @param segment.inline Inline segment definition
 #' @param anomaly.detection  Set to TRUE to include forecast data (only valid for day granularity with small date ranges)
@@ -61,7 +61,11 @@ QueueOvertime <- function(reportsuite.id, date.from, date.to, metrics,
   report.description$reportDescription$dateFrom <- unbox(date.from)
   report.description$reportDescription$dateTo <- unbox(date.to)
   report.description$reportDescription$reportSuiteID <- unbox(reportsuite.id)
-  report.description$reportDescription$dateGranularity <- unbox(date.granularity)
+  # Adobe Analytics API aggregates when dateGranularity is not set
+  # This allow for better handling of custom date ranges
+  if (date.granularity != 'aggregate') {
+    report.description$reportDescription$dateGranularity <- unbox(date.granularity)
+  }
   report.description$reportDescription$segment_id <- unbox(segment.id)
   report.description$reportDescription$anomalyDetection <- unbox(anomaly.detection)
   report.description$reportDescription$currentData <- unbox(data.current)

--- a/R/QueueTrended.R
+++ b/R/QueueTrended.R
@@ -33,7 +33,7 @@
 #' @param search List of keywords for the first specified element - e.g. c("contact","about","shop").
 #' search overrides anything specified using selected
 #' @param search.type String specifying the search type: 'and', or, 'or' 'not' (defaults to 'or')
-#' @param date.granularity Time granularity of the report (year/month/week/day/hour), default to 'day'
+#' @param date.granularity Time granularity of the report (year/month/week/day/hour/aggregate), default to 'day'
 #' @param segment.id Id of Adobe Analytics segment to retrieve the report for
 #' @param segment.inline Inline segment definition
 #' @param classification SAINT classification to use in place of first element. Need to specify element AND classification.
@@ -81,7 +81,11 @@ QueueTrended <- function(reportsuite.id, date.from, date.to, metrics, elements,
   report.description$reportDescription$dateFrom <- unbox(date.from)
   report.description$reportDescription$dateTo <- unbox(date.to)
   report.description$reportDescription$reportSuiteID <- unbox(reportsuite.id)
-  report.description$reportDescription$dateGranularity <- unbox(date.granularity)
+  # Adobe Analytics API aggregates when dateGranularity is not set
+  # This allow for better handling of custom date ranges
+  if (date.granularity != 'aggregate') {
+    report.description$reportDescription$dateGranularity <- unbox(date.granularity)
+  }
   if(segment.inline!="") {
     report.description$reportDescription$segments <- list(segment.inline)
   }


### PR DESCRIPTION
I came across this issue this morning.  I needed to utilize the aggregate date granularity available in the API.  The API uses the aggregate granularity by not passing a date granularity in the JSON request object.  I have implemented this in this pull request.  There should be no compatibility issues as I just do not set the date granularity parameter when a granularity of "aggregate" is passed in. 

Thanks,
Jason
