### PR TITLE
Fix #122

### DIFF
--- a/R/BuildInnerBreakdownsRecursively.R
+++ b/R/BuildInnerBreakdownsRecursively.R
@@ -77,7 +77,7 @@ BuildInnerBreakdownsRecursively <- function(parent.element,elements,metrics,
       # build named elements, with classifications if they exist
       elements.named <- elements$id
       for(i in 1:nrow(elements)) {
-        if(nchar(elements[i,]$classification)>0 && !is.na(elements[i,]$classification)) {
+        if(!is.null(elements[i,]$classification) && nchar(elements[i,]$classification)>0) {
           elements.named[i] <- paste0(elements[i,]$id,": ",elements[i,]$classification)
         }
       }


### PR DESCRIPTION
Switched is.na to is.null, which is the correct treatment for when a field doesn't exist in a list. I also switched the element order, so that short-circuit evaluation will determine whether the element exists first before trying to figure out how many characters it has (first element FALSE = immediately FALSE)
