### PR TITLE
Added "validate" option

### DIFF
--- a/R/QueueFallout.R
+++ b/R/QueueFallout.R
@@ -21,6 +21,7 @@
 #' @param expedite Set to TRUE to expedite the processing of this report
 #' @param interval.seconds How long to wait between attempts
 #' @param max.attempts Number of API attempts before stopping
+#' @param validate Weather to submit report definition for validation before requesting the data.
 #'
 #' @importFrom jsonlite toJSON unbox
 #'
@@ -43,7 +44,7 @@
 #' @export
 
 QueueFallout <- function(reportsuite.id, date.from, date.to, metrics, element, checkpoints,
-                        segment.id='', expedite=FALSE,interval.seconds=5,max.attempts=120) {
+                        segment.id='', expedite=FALSE,interval.seconds=5,max.attempts=120,validate=TRUE) {
   
   # build JSON description
   # we have to use unbox to force jsonlist not put strings into single-element arrays
@@ -61,7 +62,7 @@ QueueFallout <- function(reportsuite.id, date.from, date.to, metrics, element, c
   report.description$reportDescription$metrics = data.frame(id = metrics)
   report.description$reportDescription$elements = list(list(id = unbox(element), checkpoints = checkpoints))
 
-  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts)
+  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts,validate=validate)
 
   return(report.data) 
 

--- a/R/QueueOvertime.R
+++ b/R/QueueOvertime.R
@@ -24,6 +24,7 @@
 #' @param expedite Set to TRUE to expedite the processing of this report
 #' @param interval.seconds How long to wait between attempts
 #' @param max.attempts Number of API attempts before stopping
+#' @param validate Weather to submit report definition for validation before requesting the data.
 #'
 #' @importFrom jsonlite toJSON unbox
 #'
@@ -59,7 +60,7 @@
 
 QueueOvertime <- function(reportsuite.id, date.from, date.to, metrics,
                         date.granularity='day', segment.id='', segment.inline='', anomaly.detection=FALSE,
-                        data.current=FALSE, expedite=FALSE,interval.seconds=5,max.attempts=120) {
+                        data.current=FALSE, expedite=FALSE,interval.seconds=5,max.attempts=120,validate=TRUE) {
   
   # build JSON description
   # we have to use unbox to force jsonlist not put strings into single-element arrays
@@ -78,7 +79,7 @@ QueueOvertime <- function(reportsuite.id, date.from, date.to, metrics,
   }
   report.description$reportDescription$metrics = data.frame(id = metrics)
 
-  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts)
+  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts,validate=validate)
 
   return(report.data) 
 

--- a/R/QueuePathing.R
+++ b/R/QueuePathing.R
@@ -26,6 +26,7 @@
 #' @param expedite Set to TRUE to expedite the processing of this report
 #' @param interval.seconds How long to wait between attempts
 #' @param max.attempts Number of API attempts before stopping
+#' @param validate Weather to submit report definition for validation before requesting the data.
 #'
 #' @importFrom jsonlite toJSON unbox
 #'
@@ -48,7 +49,7 @@
 
 QueuePathing <- function(reportsuite.id, date.from, date.to, metric, element, pattern,
                         top=1000, start=1,
-                        segment.id='', expedite=FALSE,interval.seconds=5,max.attempts=120) {
+                        segment.id='', expedite=FALSE,interval.seconds=5,max.attempts=120,validate=TRUE) {
   
   # build JSON description
   # we have to use unbox to force jsonlist not put strings into single-element arrays
@@ -69,7 +70,7 @@ QueuePathing <- function(reportsuite.id, date.from, date.to, metric, element, pa
                                                             startingWith = unbox(start), 
                                                             pattern = as.list(pattern)))
 
-  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts)
+  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts,validate=validate)
 
   return(report.data) 
 

--- a/R/QueueRanked.R
+++ b/R/QueueRanked.R
@@ -96,7 +96,7 @@ QueueRanked <- function(reportsuite.id, date.from, date.to, metrics, elements,
     if(i==1){
       firstTop <- 
       working.element <- list(id = unbox(element), 
-                              top = unbox(top), 
+                              top = unbox(top[1]), 
                               startingWith = unbox(start))
 
       if(length(selected)!=0){

--- a/R/QueueRanked.R
+++ b/R/QueueRanked.R
@@ -38,6 +38,7 @@
 #' @param expedite Set to TRUE to expedite the processing of this report
 #' @param interval.seconds How long to wait between attempts
 #' @param max.attempts Number of API attempts before stopping
+#' @param validate Weather to submit report definition for validation before requesting the data.
 #'
 #' @importFrom jsonlite toJSON unbox
 #' @importFrom plyr rbind.fill
@@ -61,7 +62,7 @@
 QueueRanked <- function(reportsuite.id, date.from, date.to, metrics, elements,
                         top=0,start=0,selected=c(), search=c(),search.type='or',
                         segment.id='', segment.inline='', classification=c(),data.current=FALSE, 
-                        expedite=FALSE,interval.seconds=5,max.attempts=120) {
+                        expedite=FALSE,interval.seconds=5,max.attempts=120,validate=TRUE) {
 
   # build JSON description
   # we have to use unbox to force jsonlist not put strings into single-element arrays
@@ -120,7 +121,7 @@ QueueRanked <- function(reportsuite.id, date.from, date.to, metrics, elements,
   }
   report.description$reportDescription$elements <- elements.formatted
 
-  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts)
+  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts,validate=validate)
 
   return(report.data) 
 

--- a/R/QueueRanked.R
+++ b/R/QueueRanked.R
@@ -24,7 +24,7 @@
 #' @param date.to End date for the report (YYYY-MM-DD)
 #' @param metrics List of metrics to include in the report
 #' @param elements List of elements to include in the report
-#' @param top Number of elements to include (top X) - only applies to the first element.
+#' @param top List of numbers to limit the number of elements to include (top X). eg. c(10,5)
 #' @param start Start row if you do not want to start at #1 - only applies to the first element.
 #' @param selected List of specific items (of the first element) to include in the report - e.g. c("www:home","www:search","www:about").
 #' this only works for the first element (API limitation).
@@ -91,8 +91,10 @@ QueueRanked <- function(reportsuite.id, date.from, date.to, metrics, elements,
   i <- 0
   for(element in elements) {
     i <- i + 1
+
     # we only put selected, search, top and startingWith for the first element
     if(i==1){
+      firstTop <- 
       working.element <- list(id = unbox(element), 
                               top = unbox(top), 
                               startingWith = unbox(start))
@@ -106,7 +108,13 @@ QueueRanked <- function(reportsuite.id, date.from, date.to, metrics, elements,
       }
 
     } else {
-      working.element <- list(id = unbox(element), top = unbox("50000"))
+   	  # Check if the input is a vector with more than 1 element
+      if(length(top)>=i){
+      	# Use the matching limit value from vector
+      	working.element <- list(id = unbox(element), top = unbox( top[i] ))
+      } else {
+      	working.element <- list(id = unbox(element), top = unbox("50000"))
+      }
     }
 
     if(length(classification)>=i){

--- a/R/QueueRanked.R
+++ b/R/QueueRanked.R
@@ -24,7 +24,7 @@
 #' @param date.to End date for the report (YYYY-MM-DD)
 #' @param metrics List of metrics to include in the report
 #' @param elements List of elements to include in the report
-#' @param top List of numbers to limit the number of elements to include (top X). eg. c(10,5)
+#' @param top List of numbers to limit the number of rows to include (top X). eg. c(10,5)
 #' @param start Start row if you do not want to start at #1 - only applies to the first element.
 #' @param selected List of specific items (of the first element) to include in the report - e.g. c("www:home","www:search","www:about").
 #' this only works for the first element (API limitation).

--- a/R/QueueSummary.R
+++ b/R/QueueSummary.R
@@ -22,6 +22,7 @@
 #' @param metrics List of metrics to include in the report
 #' @param interval.seconds How long to wait between attempts
 #' @param max.attempts Number of API attempts before stopping
+#' @param validate Weather to submit report definition for validation before requesting the data.
 #'
 #' @importFrom jsonlite toJSON unbox
 #' 
@@ -37,7 +38,7 @@
 #'
 #' @export
 
-QueueSummary <- function(reportsuite.ids, date, metrics, interval.seconds=5, max.attempts=120) {
+QueueSummary <- function(reportsuite.ids, date, metrics, interval.seconds=5, max.attempts=120,validate=TRUE) {
   
   # build JSON description
   # we have to use unbox to force jsonlist not put strings into single-element arrays
@@ -48,7 +49,7 @@ QueueSummary <- function(reportsuite.ids, date, metrics, interval.seconds=5, max
   report.description$reportDescription$metrics <- data.frame(id = metrics)
   report.description$reportDescription$elements <- list(list(id = unbox("reportsuite"), selected=c(reportsuite.ids)))
   
-  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts)
+  report.data <- SubmitJsonQueueReport(toJSON(report.description),interval.seconds=interval.seconds,max.attempts=max.attempts,validate=validate)
   
   return(report.data) 
   

--- a/R/SubmitJsonQueueReport.R
+++ b/R/SubmitJsonQueueReport.R
@@ -11,6 +11,7 @@
 #' @param report.description JSON report description
 #' @param interval.seconds How long to wait between attempts
 #' @param max.attempts Number of API attempts before stopping
+#' @param validate Weather to submit report definition for validation before requesting the data.
 #'
 #' @importFrom jsonlite toJSON unbox
 #'
@@ -28,6 +29,7 @@
 
 SubmitJsonQueueReport <- function(report.description,interval.seconds=5,max.attempts=120,validate=TRUE) {
 
+  # Determine if we should validate the definition
   if(validate) {
     if(!ValidateReport(report.description)) {
       stop("ERROR: Invalid report description.")

--- a/R/SubmitJsonQueueReport.R
+++ b/R/SubmitJsonQueueReport.R
@@ -26,12 +26,14 @@
 #' @export
 #'
 
-SubmitJsonQueueReport <- function(report.description,interval.seconds=5,max.attempts=120) {
+SubmitJsonQueueReport <- function(report.description,interval.seconds=5,max.attempts=120,validate=TRUE) {
 
-  if(!ValidateReport(report.description)) {
-    stop("ERROR: Invalid report description.")
+  if(validate) {
+    if(!ValidateReport(report.description)) {
+      stop("ERROR: Invalid report description.")
+    }
   }
-
+  
   response <- ApiRequest(body=report.description,func.name="Report.Queue")
   
   #If response returns an error, return error message. Else, continue with capturing report ID


### PR DESCRIPTION
Queue* functions now include a "validate" option. Defaults to TRUE.

This option enables developers to skip validation of report definitions. This can improve performance in scripted jobs.