### PR TITLE
Better handling for report ID

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,8 @@ RSiteCatalyst 1.4.6
 
 * Both features submitted graciously by Tim Findlay
 
+* Added handler for inconsistent reportID data type returned by the API
+
 RSiteCatalyst 1.4.5
 =================
 * Removed SCAuth function internal argument use.1.3, no longer needed

--- a/R/SubmitJsonQueueReport.R
+++ b/R/SubmitJsonQueueReport.R
@@ -39,10 +39,9 @@ SubmitJsonQueueReport <- function(report.description,interval.seconds=5,max.atte
   response <- ApiRequest(body=report.description,func.name="Report.Queue")
   
   #If response returns an error, return error message. Else, continue with capturing report ID
-  if(!is.numeric(response$reportID)) {
+  report.id <- as.numeric(response$reportID)
+  if(!is.numeric(report.id)) {
     stop("ERROR: the API validated the report, but did not return a report ID")
-  } else {
-    report.id <- response$reportID
   }
 
   request.body <- c()


### PR DESCRIPTION
Handles report ID when Adobe returns it as a string.